### PR TITLE
Add --watch and -w flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You can use `textr` with specified options:
 *  `-t`, `--transforms` — array of transformers, which will be applied (transformers should be installed globaly or localy in current project);
 * `-o`, `--out-file` — write output to file;
 * `-l`, `--locale` — ISO 639 locale codes (`en-us` as default);
+* `-w`, `--watch` — Watch changes in source file (works only with input as first argument and output through `-o` or `--out-file` flags);
 * `-h`, `--help` — show help message.
 
 ## Real world

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "homepage": "https://github.com/denysdovhan/textr-cli#readme",
   "devDependencies": {
     "assert": "^1.3.0",
-    "babel": "^6.0.15",
     "babel-cli": "^6.0.12",
     "babel-core": "^6.0.20",
     "babel-eslint": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "typographic-single-spaces": "^1.0.2"
   },
   "dependencies": {
+    "chokidar": "^1.2.0",
     "get-stdin": "^5.0.0",
     "meow": "^3.5.0",
     "textr": "^0.3.0"


### PR DESCRIPTION
Add watching features. Now `textr` support `--watch` and `-w` flags for watching source files. Just take a look:

![textr-watch](https://cloud.githubusercontent.com/assets/3459374/11163899/e7385548-8ae9-11e5-8e8c-6c9f1e529ddd.gif)

**P.S** It's working only with `-o` and `--out-file` flags, bcoz I don't know how to clear `stdout` for using `>`.

@iamstarkov, @shuvalov-anton what are you thinking about this?
